### PR TITLE
add project compile classpath to javadoc -classpath arg

### DIFF
--- a/src/main/scala/javadoc.scala
+++ b/src/main/scala/javadoc.scala
@@ -24,7 +24,10 @@ object JavadocPlugin extends Plugin {
   }
 
   val javadocSettings = Seq(
-    javadocOptions := Seq("-link", "http://download.oracle.com/javase/6/docs/api/"),
+    javadocOptions <<= (fullClasspath in Compile) map { fcp => Seq(
+        "-link", "http://download.oracle.com/javase/6/docs/api/"
+      , "-classpath", fcp.map(_.data).map(_.getPath).mkString(java.io.File.pathSeparator)
+    )},
     javadoc <<= (target in javadoc, javaSource in Compile, javadocSubpackages, javadocOptions, streams) map {
       (t, source, pkgs, opts, s) => javadocTask(t, source, pkgs, opts, s.log)
     },


### PR DESCRIPTION
This addresses [Java Bug 6442982](http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6442982), which causes exceptions preventing full javadoc generation:

> `java.lang.ClassCastException: com.sun.tools.javadoc.ClassDocImpl cannot be cast to com.sun.javadoc.AnnotationTypeDoc`

See also:
- http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6442982
- http://stackoverflow.com/questions/44853/why-am-i-getting-a-classcastexception-when-generating-javadocs
- http://stackoverflow.com/questions/5314738/javadoc-annotations-from-third-party-libraries
